### PR TITLE
Add basic auth support for Redash MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ REDASH_TIMEOUT=30000
 
 # Optional: Maximum number of results to return
 REDASH_MAX_RESULTS=1000
+
+# Optional: Basic authentication credentials if your Redash instance is behind basic auth
+REDASH_BASIC_AUTH_USERNAME=
+REDASH_BASIC_AUTH_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The server requires the following environment variables:
 Optional variables:
 - `REDASH_TIMEOUT`: Timeout for API requests in milliseconds (default: 30000)
 - `REDASH_MAX_RESULTS`: Maximum number of results to return (default: 1000)
+- `REDASH_BASIC_AUTH_USERNAME` / `REDASH_BASIC_AUTH_PASSWORD`: Basic auth credentials if your Redash instance is protected
 
 ## Installation
 

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -108,14 +108,32 @@ export class RedashClient {
       throw new Error('REDASH_URL and REDASH_API_KEY must be provided in .env file');
     }
 
-    this.client = axios.create({
+    const basicAuthUser = process.env.REDASH_BASIC_AUTH_USERNAME;
+    const basicAuthPass = process.env.REDASH_BASIC_AUTH_PASSWORD;
+
+    const axiosConfig: any = {
       baseURL: this.baseUrl,
       headers: {
-        'Authorization': `Key ${this.apiKey}`,
         'Content-Type': 'application/json'
       },
       timeout: parseInt(process.env.REDASH_TIMEOUT || '30000')
-    });
+    };
+
+    if (basicAuthUser && basicAuthPass) {
+      const token = Buffer.from(`${basicAuthUser}:${basicAuthPass}`).toString('base64');
+      axiosConfig.headers['Authorization'] = `Basic ${token}`;
+    } else {
+      axiosConfig.headers['Authorization'] = `Key ${this.apiKey}`;
+    }
+
+    this.client = axios.create(axiosConfig);
+
+    if (basicAuthUser && basicAuthPass) {
+      this.client.interceptors.request.use((config) => {
+        config.params = { ...(config.params || {}), api_key: this.apiKey };
+        return config;
+      });
+    }
   }
 
   // Get all queries (with pagination)


### PR DESCRIPTION
## Summary
- allow using MCP with Redash instances protected by HTTP basic auth
- document new optional environment variables

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6874abe5e74883258cf25f456fa91481